### PR TITLE
bugfix for safari native ios browser on iphone

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -47,7 +47,7 @@
         top: 0;
         left: 0;
         width: 100%;
-        max-height: 20%;
+        max-height: 10%;
         overflow-y: auto;
         background: rgba(0,0,0,0.8);
         color: #0f0;

--- a/frontend/js/features/audio/lib/streamTrick.js
+++ b/frontend/js/features/audio/lib/streamTrick.js
@@ -23,10 +23,13 @@ export function getAudioCtx() {
 }
 
 
-
-function isIosSafari() {
-    return /iP(ad|hone|od).+Version\/[\d.]+.*Safari/i.test(navigator.userAgent);
+//HOLY JESUS THIS IS TURBO GARBAGE 
+function isIosSafari() { 
+    const userAgent = navigator.userAgent; 
+    logDebug(`userAgent: ${userAgent}`); 
+    return /Safari/i.test(userAgent) && /AppleWebKit/i.test(userAgent) && !/Chrome|Android/i.test(userAgent); 
 }
+
 
 /**
  * Handles interruptions to the AudioContext (iOS Safari, phone calls, other media)


### PR DESCRIPTION
* bugfix for safari native ios browser failing to be identified correctly in streamTrick.js file, using more permissible isIosSafari() function. in a future case where we don't see a debuglog for "loadTrack iOS detected" then this may be the issue
* edited height of debuglog to allow viewing more stuff