### PR TITLE
Playlist importing

### DIFF
--- a/backend/api/routers/playlists_router.py
+++ b/backend/api/routers/playlists_router.py
@@ -1,3 +1,4 @@
+import traceback
 from typing import Optional
 from fastapi import APIRouter, Query, Request, HTTPException, Response
 from fastapi.responses import JSONResponse
@@ -5,6 +6,11 @@ from fastapi.responses import JSONResponse
 
 from backend.api.schemas.playlist_schemas import CreatePlaylistRequest, DeleteTrackRequest, EditTrackRequest
 from backend.core.database.audio_database import AudioDatabase
+from backend.core.models.download_job import DownloadJob
+from backend.core.playlists.manager import PlaylistExtractorManager
+
+import backend.globals as G
+
 
 
 router = APIRouter(prefix="/playlists")
@@ -48,26 +54,60 @@ async def get_playlist_content(req: Request, id: Optional[int] = Query(None)):
 async def create_playlist(body: CreatePlaylistRequest, req: Request) -> Response:
     """
     Creates a new playlist in the database.
+    If 'import_url' is provided, performs additional processing.
 
     Args:
-        body (QueuePushTrackRequest): Request body containing the Track to push.
+        body (CreatePlaylistRequest): Request body containing temp_id, name, and optional import_url.
         req (Request): FastAPI request object to access app state.
 
     Returns:
-        JSONResponse: The updated play queue serialized as JSON.
+        JSONResponse: Status creation
 
     Raises:
-        HTTPException: Returns 500 if any unexpected error occurs during processing.
+        HTTPException: Returns 400 if name is blank.
+        HTTPException: 500 for unexpected errors.
     """
     temp_id = body.temp_id
-    name = body.name
+    name = body.name.strip() if body.name else ""
+    url = body.import_url.strip() if body.import_url else None
+
+    if not name:
+        raise HTTPException(status_code=400, detail="Playlist name cannot be empty")
 
     db: AudioDatabase = req.app.state.db
+    playlist_ext_manager: PlaylistExtractorManager = req.app.state.playlist_ext_manager
 
-    await db.create_playlist(name=name, temp_id=temp_id)
+    queue_manager = req.app.state.queue_manager
+    download_queue = queue_manager.get(G.DOWNLOAD_QUEUE_NAME)
 
-    return JSONResponse(content={"status": "created"}, status_code=200)
+    try:
+        #make playlist and hold onto id to add songs into it if import required
+        content = await db.create_playlist(name=name, temp_id=temp_id) #database handles id conflicts
 
+        #handle importing
+        if url:
+            extracted_tracks = playlist_ext_manager.fetch_data(url) #should return [] in worst case
+            playlist_id = content.get("id")
+
+            for track in extracted_tracks:
+                job = DownloadJob(
+                    query=track.get("download_query"), 
+                    metadata=track.get("metadata"),
+                    updates=[
+                        {
+                            "id": playlist_id,
+                            "checked": True
+                        }
+                    ]
+                )
+                await download_queue.push(job)
+
+        return JSONResponse(content={"status": "created"}, status_code=200)
+    
+    except Exception as e:
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail=str(e))
+    
 
 
 

--- a/backend/api/schemas/playlist_schemas.py
+++ b/backend/api/schemas/playlist_schemas.py
@@ -5,6 +5,7 @@ from backend.core.models.track import Track
 class CreatePlaylistRequest(BaseModel):
     temp_id: str
     name: str
+    import_url: Optional[str]
 
 
 class PlaylistSelection(BaseModel):

--- a/backend/core/database/audio_database.py
+++ b/backend/core/database/audio_database.py
@@ -348,7 +348,7 @@ class AudioDatabase:
             }
             await self._emit_event(action=ADA.CREATE_PLAYLIST, payload={"content": content})
             
-            return 
+            return content
         
     async def get_all_playlists(self):
         async with self._lock:

--- a/backend/core/lib/utils.py
+++ b/backend/core/lib/utils.py
@@ -26,3 +26,20 @@ def is_downloaded(track_or_id: Union[str, Track], base_dir: Path = G.DOWNLOAD_DI
 
 def get_audio_size(track_or_id: Union[str, Track], base_dir: Path = G.DOWNLOAD_DIR, audio_format: str = G.AUDIO_FORMAT) -> int:
     return get_audio_path(track_or_id, base_dir, audio_format).stat().st_size
+
+
+#recursively search for first occurrence of a key in a nested dict json
+def find_key(obj, key):
+    if isinstance(obj, dict):
+        if key in obj:
+            return obj[key]
+        for v in obj.values():
+            result = find_key(v, key)
+            if result is not None:
+                return result
+    elif isinstance(obj, list):
+        for item in obj:
+            result = find_key(item, key)
+            if result is not None:
+                return result
+    return None

--- a/backend/core/models/download_job.py
+++ b/backend/core/models/download_job.py
@@ -1,15 +1,38 @@
 from typing import Optional
 
 class DownloadJob:
+    """
+    Represents a download task for a track.
+    Will need either id or query to be valid, but we shouldn't ever reach this error
+
+    Args:
+        id: Optional unique ID for the track, which may be extracted from a query
+        query: Optional search query to fetch the track. 
+        metadata: Optional track metadata, expected format:
+            {
+                "title": str,
+                "artist": str,
+                ...etc
+            }
+        updates: Optional dictionary indicating which playlists this track should be added to after download:
+            {
+                playlist_id: True #see audio_database.update_track_playlists()
+            }
+    """
     def __init__(
         self,
         id: Optional[str] = None,
         query: Optional[str] = None,
-        metadata: Optional[dict] = None
+        metadata: Optional[dict] = None,
+        updates: Optional[dict] = None
     ):
+        if not id and not query:
+            raise ValueError("Either 'id' or 'query' must be provided.")
+        
         self.id = id
         self.query = query
         self.metadata = metadata
+        self.updates = updates #follows convention of {playlist_id: checked(bool)}
 
     def get_type(self) -> str:
         if self.id:
@@ -26,6 +49,10 @@ class DownloadJob:
     
     def get_metadata(self) -> dict | None:
         return self.metadata
+    
+    def get_updates(self) -> dict | None:
+        return self.updates
+
 
     def get_identifier(self) -> str:
         """

--- a/backend/core/models/download_job.py
+++ b/backend/core/models/download_job.py
@@ -1,30 +1,38 @@
 from typing import Optional
-from backend.core.models.track import Track
 
 class DownloadJob:
     def __init__(
         self,
-        track: Optional[Track] = None,
         id: Optional[str] = None,
-        query: Optional[str] = None
+        query: Optional[str] = None,
+        metadata: Optional[dict] = None
     ):
-        self.track = track
         self.id = id
         self.query = query
+        self.metadata = metadata
 
     def get_type(self) -> str:
-        if self.track:
-            return "Track"
         if self.id:
             return "id"
         if self.query:
             return "query"
         return "unknown"
+    
+    def get_id(self) -> str | None:
+        return self.id
+    
+    def get_query(self) -> str | None:
+        return self.query
+    
+    def get_metadata(self) -> dict | None:
+        return self.metadata
 
     def get_identifier(self) -> str:
-        """Return a string uniquely identifying this job."""
-        if self.track:
-            return self.track.id
+        """
+        Return a string uniquely identifying this job.
+        For id, returns the id.
+        For query, returns the entire query string.
+        """
         if self.id:
             return self.id
         if self.query:

--- a/backend/core/models/download_job.py
+++ b/backend/core/models/download_job.py
@@ -42,9 +42,9 @@ class DownloadJob:
     def to_json(self) -> dict:
         return {
             "type": self.get_type(),
-            "track": self.track.to_json() if self.track else None,
             "id": self.id,
-            "query": self.query
+            "query": self.query,
+            "metadata": self.metadata
         }
 
     def __repr__(self):

--- a/backend/core/models/enums.py
+++ b/backend/core/models/enums.py
@@ -6,6 +6,8 @@ class YouTubeClientAction(str, Enum):
     SEARCH = "search"
     DOWNLOAD = "download"
 
+    ERROR = "error"
+
     START = "task_start"
     FINISH = "task_finish"
 

--- a/backend/core/playlists/base/extractor.py
+++ b/backend/core/playlists/base/extractor.py
@@ -1,0 +1,28 @@
+from abc import ABC, abstractmethod
+
+class PlaylistExtractor(ABC):
+    def __init__(self, url=None):
+        self.url = url
+        self.id = None
+        self.tracks = []
+
+        self.HEADERS = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Referer": "https://www.google.com/"
+        }
+
+    def set_url(self, url):
+        self.url = url
+
+    @abstractmethod
+    def matches_url(self) -> bool:
+        """Return True if this extractor can handle the URL"""
+        pass
+
+    @abstractmethod
+    def fetch_data(self):
+        """Fetch and parse playlist data"""
+        pass

--- a/backend/core/playlists/implementations/spotify_playlist_ext.py
+++ b/backend/core/playlists/implementations/spotify_playlist_ext.py
@@ -1,0 +1,86 @@
+import requests
+import re
+import json
+from urllib.parse import urlparse
+
+from backend.core.lib.utils import find_key
+from backend.core.playlists.base.extractor import PlaylistExtractor
+
+
+class SpotifyPlaylistExtractor(PlaylistExtractor):
+    def matches_url(self) -> bool:
+        return "spotify.com/playlist" in self.url or "spotify:playlist:" in self.url #URI handling too
+    
+
+    def _embed_url(self):
+        # handles forms like:
+        # https://open.spotify.com/playlist/<id>?si=...
+        # https://open.spotify.com/playlist/<id>
+        #needs handling for URI?
+        try:
+            p = urlparse(self.url)
+            parts = p.path.split("/")
+            idx = parts.index("playlist")
+            playlist_id = parts[idx + 1]
+        except Exception:
+            #fallback regex
+            m = re.search(r"playlist/([A-Za-z0-0]+)", self.url)
+            playlist_id = m.group(1) if m else None
+
+        if not playlist_id:
+            raise ValueError(f"Could not extract playlist ID from URL: {self.url}")
+
+        return f"https://open.spotify.com/embed/playlist/{playlist_id}"
+
+
+
+    def _clean_text(self, s: str) -> str:
+        """Clean up weird characters, spot has \xa0 which is non-breaking space"""
+        if not s:
+            return ""
+        s = s.replace("\xa0", " ")
+        return s
+    
+
+    def fetch_data(self):
+        #get optimal webpage for scraping
+        embed_url = self._embed_url()
+        #print(f"embed_url: {embed_url}")
+
+        r = requests.get(embed_url, headers=self.HEADERS, timeout=15)
+        r.raise_for_status()
+
+        #scrape
+        html = r.text
+        match = re.search(r'<script[^>]+type="application/json"[^>]*>(.*?)</script>', html, re.DOTALL)
+        if not match:
+            raise ValueError("No JSON script tag found")
+
+        data = json.loads(match.group(1))
+
+        #after digging through the data this is probably optimal
+        #test using this command in case spotify breaks some shit
+        # print(json.dumps(data, indent=4))
+        keyword = "trackList"
+        track_list = find_key(data, keyword) 
+        
+        #validation
+        if not track_list:
+            raise ValueError(f"Failed to locate '{keyword}' in Spotify embed JSON. The structure may have changed")
+        
+        for i, t in enumerate(track_list):
+            if "title" not in t or "subtitle" not in t:
+                raise ValueError(f"Track at index {i} is missing one or more required fields: {t}")
+
+        #clean it up and send it back
+        tracks = [
+            {
+                "title": self._clean_text(t["title"]), 
+                "artist": self._clean_text(t["subtitle"])
+            } for t in track_list or []
+        ]
+        
+        for t in tracks:
+            print(t)
+
+        return tracks

--- a/backend/core/playlists/implementations/spotify_playlist_ext.py
+++ b/backend/core/playlists/implementations/spotify_playlist_ext.py
@@ -34,7 +34,7 @@ class SpotifyPlaylistExtractor(PlaylistExtractor):
 
 
 
-    def _clean_text(self, s: str) -> str:
+    def _clean(self, s: str) -> str:
         """Clean up weird characters, spot has \xa0 which is non-breaking space"""
         if not s:
             return ""
@@ -68,19 +68,28 @@ class SpotifyPlaylistExtractor(PlaylistExtractor):
         if not track_list:
             raise ValueError(f"Failed to locate '{keyword}' in Spotify embed JSON. The structure may have changed")
         
-        for i, t in enumerate(track_list):
-            if "title" not in t or "subtitle" not in t:
-                raise ValueError(f"Track at index {i} is missing one or more required fields: {t}")
+        for i, track in enumerate(track_list):
+            if "title" not in track or "subtitle" not in track:
+                raise ValueError(f"Track at index {i} is missing one or more required fields: {track}")
+            
+
 
         #clean it up and send it back
-        tracks = [
-            {
-                "title": self._clean_text(t["title"]), 
-                "artist": self._clean_text(t["subtitle"])
-            } for t in track_list or []
-        ]
-        
-        for t in tracks:
-            print(t)
+        tracks = []
+        for t in track_list or []:
+            title = self._clean(t.get("title", ""))
+            artist = self._clean(t.get("subtitle", ""))
+            tracks.append({
+                "download_query": f"{title} by {artist}",
+                "metadata": {
+                    "title": title,
+                    "artist": artist
+                }
+            })
+
+
+        #debugging
+        # for t in tracks:
+        #     print(json.dumps(t, indent=4))
 
         return tracks

--- a/backend/core/playlists/manager.py
+++ b/backend/core/playlists/manager.py
@@ -1,0 +1,26 @@
+import traceback
+from backend.core.playlists.implementations.spotify_playlist_ext import SpotifyPlaylistExtractor
+
+class PlaylistExtractorManager:
+    def __init__(self):
+        self.extractor_classes = [
+            SpotifyPlaylistExtractor
+        ]
+
+    def fetch_data(self, url):
+        for extractor_cls in self.extractor_classes:
+            extractor = extractor_cls(url)
+
+            if extractor.matches_url():
+                try:
+                    return extractor.fetch_data()
+                except Exception as e:
+                    print(f"Extractor {extractor_cls.__name__} failed: {e}")
+                    traceback.print_exc()
+                    return []
+        
+        #failed to find an extractor
+        print("Failed to find an appropriate extractor")
+        return []
+    
+        

--- a/backend/core/worker/download.py
+++ b/backend/core/worker/download.py
@@ -41,10 +41,15 @@ class DownloadWorker:
                     case _:
                         print(f"[WARN] Unknown DownloadJob type: {job.get_type()}")
                         continue
-                    
+
+                #client should return the classic Track metadata with {id, title, artist, dur} 
                 if track:
                     await self.audio_database.log_track(track)
                     await self.audio_database.log_download(track.id)
+
+                    #put into a playlist right away? in the case of importing a playlist then yes
+                    if job.get_updates():
+                        await self.audio_database.update_track_playlists(track.id, job.get_updates())
 
             except Exception as e:
                 print(f"[ERROR] DownloadWorker error ({e}) handling DownloadJob: {job}\n{traceback.format_exc()}")

--- a/backend/core/youtube/client.py
+++ b/backend/core/youtube/client.py
@@ -333,6 +333,7 @@ class YouTubeClient:
         self,
         q: str,
         timeout: int = 60,
+        custom_metadata: Optional[dict] = None
     ) -> bool:
         
         result = await self.robust_search(q=q, limit=1, timeout=timeout) #doesnt emit when searching 1 item
@@ -344,7 +345,7 @@ class YouTubeClient:
         id = result[0].id
         print(f"[DEBUG] Result: {result}, ID: {id}")
 
-        track = await self.download_by_id(id, timeout=timeout)
+        track = await self.download_by_id(id, timeout=timeout, custom_metadata=custom_metadata)
         print(f"[DEBUG] Track: {track}")
 
         return track

--- a/backend/core/youtube/client.py
+++ b/backend/core/youtube/client.py
@@ -243,8 +243,13 @@ class YouTubeClient:
     async def download_by_id(
         self,
         id: str, 
-        timeout: int = 60
+        timeout: int = 60,
+        custom_metadata: Optional[dict] = None
     ) -> bool:
+        """
+        Downloads a track given a Youtube ID using ytdlp and returns a Track object.
+        If custom_track is provided, its fields override the downloaded metadata.
+        """
         #send task start notification
         await self._emit_event(action=YTCA.START, payload={})
 
@@ -278,21 +283,26 @@ class YouTubeClient:
         ]
         print(f"Running command: {' '.join(cmd)}")
 
+        track = None
         try:
             start_time = time.time()
             code, out, err = await self._run_subprocess(cmd, timeout=timeout)
 
             if code != 0:
-                raise RuntimeError(f"yt-dlp exited with code {code}: {err.strip()}")
+                raise RuntimeError(f"[download_by_id] yt-dlp exited with code {code}: {err.strip()}")
         
             elapsed = time.time() - start_time
             print(f"[INFO] Downloaded {id} in {elapsed:.2f}s")
 
             # Parse metadata from stdout
-            line = out.strip().splitlines()[0]  # first line
-            id, title, artist, duration = line.split(delim)
-            true_id = f"{self.id_src}{id}"
+            try:
+                line = out.strip().splitlines()[0]  # first line
+                id, title, artist, duration = line.split(delim)
+            except Exception as e:
+                raise ValueError(f"[download_by_id] Failed to parse metadata: {e}, Output was: {out}")
 
+            #build track object
+            true_id = f"{self.id_src}{id}"
             track = Track(
                 id=true_id,
                 title=title or "Unknown Title",
@@ -300,17 +310,24 @@ class YouTubeClient:
                 duration=int(duration) if duration.isdigit() else 0
             )
 
+            #override custom fields
+            if custom_metadata:
+                for k, v in custom_metadata.items():
+                    if v not in (None, "") and hasattr(track, k):
+                        setattr(track, k, v)
+
+            await self._emit_event(action=YTCA.DOWNLOAD, payload={"content": track})
+            return track
+
         except Exception as e:
             print(f"[ERROR] Failed to download {id}: {e}")
+            await self._emit_event(action=YTCA.ERROR, payload={})
             raise
         
         finally:
             #complete task notification
-            await self._emit_event(action=YTCA.DOWNLOAD, payload={"content": track})
             await self._emit_event(action=YTCA.FINISH, payload={})
-        
-        return track
-        
+                
 
     async def download_by_query(
         self,

--- a/backend/server.py
+++ b/backend/server.py
@@ -18,6 +18,9 @@ from backend.core.queue.manager import QueueManager
 from backend.core.queue.implementations.play_queue import PlayQueue
 from backend.core.queue.implementations.download_queue import DownloadQueue
 
+from backend.core.playlists.manager import PlaylistExtractorManager
+
+
 import backend.globals as G
 
 from backend.api.routers import audio_router
@@ -55,6 +58,8 @@ async def lifespan(app: FastAPI):
     queue_manager.add(play_queue)
     queue_manager.add(download_queue)
 
+    playlist_ext_manager = PlaylistExtractorManager()
+
     # workers
     download_worker = DownloadWorker(download_queue=download_queue, youtube_client=yt, audio_database=db)
     download_task = asyncio.create_task(download_worker.run())
@@ -63,6 +68,8 @@ async def lifespan(app: FastAPI):
     app.state.websocket_manager = websocket_manager
     app.state.event_bus = event_bus
     app.state.queue_manager = queue_manager
+
+    app.state.playlist_ext_manager = playlist_ext_manager
 
     app.state.db = db
     app.state.yt = yt

--- a/frontend/css/popup.css
+++ b/frontend/css/popup.css
@@ -106,8 +106,8 @@
 }
 
 
-/* edit track metadata */
-.edit-track-metadata-menu {
+/* edit track metadata and track creation import inputs */
+.multi-input-menu {
     display: flex;
     flex-direction: column;
 

--- a/frontend/css/popup.css
+++ b/frontend/css/popup.css
@@ -71,6 +71,17 @@
     gap: var(--space-m);
 }
 
+/* no playlists available */
+.no-playlists-message {
+    background: transparent;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: none;
+    font: var(--p);
+    color: var(--text-3);
+}
+
 .playlist-selection-menu .playlist-option {
     display: flex;
     flex-direction: row;

--- a/frontend/js/dom/builder.js
+++ b/frontend/js/dom/builder.js
@@ -82,6 +82,8 @@ export function buildCreatePlaylistPopup() {
 
         <input class="menu-input js-create-playlist-input" type="text" placeholder="New name">
 
+        <input class="menu-input js-import-playlist-input" type="text" placeholder="(Optional) Link">
+
         <div class="popup-actions">
             <button class="menu-button green js-save">Save</button>
             <button class="menu-button js-cancel">Cancel</button>

--- a/frontend/js/dom/builder.js
+++ b/frontend/js/dom/builder.js
@@ -78,17 +78,24 @@ export function buildCreatePlaylistPopup() {
     popup.classList.add("popup-content");
     
     popup.innerHTML = `
-        <h3 class="popup-message">Create Playlist</h3>
+        <div class="scrollable-popup-content">
 
-        <input class="menu-input js-create-playlist-input" type="text" placeholder="New name">
+            <h3 class="popup-message">Create Playlist</h3>
 
-        <input class="menu-input js-import-playlist-input" type="text" placeholder="(Optional) Link">
+            <div class="multi-input-menu">
+                <input class="menu-input js-create-playlist-input" type="text" placeholder="New name">
+        
+                <input class="menu-input js-import-playlist-input" type="text" placeholder="(Optional) Link">
+            </div>
 
+        </div>
+        
         <div class="popup-actions">
             <button class="menu-button green js-save">Save</button>
             <button class="menu-button js-cancel">Cancel</button>
         </div>
     `;
+
     return popup;
 }
 
@@ -132,7 +139,7 @@ export function buildEditTrackPopup(playlists, track) {
 
             <h3 class="popup-message">Track Information</h3>
 
-            <div class="edit-track-metadata-menu">
+            <div class="multi-input-menu">
                 <input type="text" class="menu-input js-track-title" value="${track.title}" placeholder="Title..." />
             
                 <input type="text" class="menu-input js-track-artist" value="${track.artist}" placeholder="Artist..." />

--- a/frontend/js/dom/builder.js
+++ b/frontend/js/dom/builder.js
@@ -103,18 +103,26 @@ export function buildEditTrackPopup(playlists, track) {
     //     {"id": 3, "name": "test3", "checked": true}        
     // ]
     console.log("TRACK DATA", track);
+
+    const playlistsHTML = playlists.length > 0
+        ? playlists.map(pl => `
+            label class="playlist-option ${pl.checked ? 'checked' : ''}" data-id="${pl.id}">
+                <span class="checkbox"></span>
+                <p class="playlist-name">${pl.name}</p>
+            </label>
+        `).join("")
+        : 
+        `<div class="no-playlists-message">
+            <p>No playlists available</p>
+        </div>`;
+
     popup.innerHTML = `
         <div class="scrollable-popup-content">
 
             <h3 class="popup-message">Playlists</h3>
 
             <div class="playlist-selection-menu">
-                ${playlists.map(pl => `
-                    <label class="playlist-option ${pl.checked ? 'checked' : ''}" data-id="${pl.id}">
-                        <span class="checkbox"></span>
-                        <p class="playlist-name">${pl.name}</p>
-                    </label>
-                `).join("")}
+                ${playlistsHTML}
             </div>
 
             <div class="spacing-block">

--- a/frontend/js/features/playlist/lib/api.js
+++ b/frontend/js/features/playlist/lib/api.js
@@ -40,7 +40,7 @@ export async function getPlaylistContent(id) {
     return data;
 }
 
-export async function createPlaylist(tempId, name) {
-    const response = await postRequest(`/playlists/create`, { "temp_id": tempId, "name": name });
+export async function createPlaylist(tempId, name, importUrl) {
+    const response = await postRequest(`/playlists/create`, { "temp_id": tempId, "name": name, "import_url": importUrl });
     console.log("createPlaylist status:", response.status);
 }

--- a/frontend/js/features/popup/controller.js
+++ b/frontend/js/features/popup/controller.js
@@ -136,22 +136,25 @@ export function showCreatePlaylistPopup() {
     });
 
     const saveButtonEl = newPopupEl.querySelector(".js-save");
-    saveButtonEl.addEventListener("click", () => {
+    saveButtonEl.addEventListener("click", async () => {
         const createPlaylistInputEl = newPopupEl.querySelector(".js-create-playlist-input");
+        const importPlaylistInputEl = newPopupEl.querySelector(".js-import-playlist-input");
 
-        onCreatePlaylist(customPlaylistEl, createPlaylistInputEl); //no await?
         hidePopup(popupOverlayEl);
+        await onCreatePlaylist(customPlaylistEl, createPlaylistInputEl, importPlaylistInputEl); //no await?
     })
 
     //show
     showPopup(popupOverlayEl);
 }
 
-async function onCreatePlaylist(customPlaylistEl, createPlaylistInputEl) {
+async function onCreatePlaylist(customPlaylistEl, createPlaylistInputEl, importPlaylistInputEl) {
     //if length of input > 0 then 
     // 1) update local playlists, 2) update visuals via playlistUI, 3) send rest call via playlistAPI.
-    //listen for websocket update.    
+    //listen for websocket update.
     const name = createPlaylistInputEl.value.trim(); //extract and only do stuff if greater than length 0
+    const importUrl = importPlaylistInputEl.value.trim();
+
     if (name.length > 0) {
         logDebug("create playlist triggered");
 
@@ -161,7 +164,8 @@ async function onCreatePlaylist(customPlaylistEl, createPlaylistInputEl) {
         const newCustomListEl = renderNewCustomPlaylist(customPlaylistEl, name, null, tempId);
         renderPlaylist(newCustomListEl, []);
 
-        await createPlaylist(tempId, name);
+        //backend call
+        await createPlaylist(tempId, name, importUrl);
     }
 }
 

--- a/test_spotify_fetch.py
+++ b/test_spotify_fetch.py
@@ -7,7 +7,7 @@ from backend.core.playlists.manager import PlaylistExtractorManager
 x = PlaylistExtractorManager()
 
 url = "https://open.spotify.com/playlist/1Qw9TOwrabuxluP08Qsx97?si=3NAEqgBNRZW2nMrunsuiBg&pi=kq9EXMeBRIuEr&nd=1&dlsi=3cc87dfe883f4c20"
-x.fetch_data(url)
+print(x.fetch_data(url))
 
 url2 = "https://hello-world.com/"
-x.fetch_data(url2)
+print(x.fetch_data(url2))

--- a/test_spotify_fetch.py
+++ b/test_spotify_fetch.py
@@ -1,0 +1,13 @@
+# test_spotify_fetch.py
+
+from backend.core.playlists.implementations.spotify_playlist_ext import SpotifyPlaylistExtractor
+from backend.core.playlists.manager import PlaylistExtractorManager
+
+
+x = PlaylistExtractorManager()
+
+url = "https://open.spotify.com/playlist/1Qw9TOwrabuxluP08Qsx97?si=3NAEqgBNRZW2nMrunsuiBg&pi=kq9EXMeBRIuEr&nd=1&dlsi=3cc87dfe883f4c20"
+x.fetch_data(url)
+
+url2 = "https://hello-world.com/"
+x.fetch_data(url2)


### PR DESCRIPTION
* helper to scrape spotify share links and build a playlist.
* downloading client and download worker threads have support for setting up a playlist with tracks/track queries supplied. In particular downloading worker(!!) handles updating the database, but downloading client(!!!!!) returns the correct names. if in the future new handlers are made for downloading from different sources it will have to abide by these things and probably should write some documentation for this
* ui correctly shows optional playlist import field, and backend handles bad links correctly so far. 
* TODO: ensure backend can handle downloading duplicates, like in the case where something has already been downloaded, it shouldn't replace existing entries in the database (ex, song A is in the database and in multiple playlists, and importing playlist triggers a redownload which wipes the existing data. catastrophic)