### PR TITLE
supports removing from queue. big infrastructural change to options a…

### DIFF
--- a/backend/api/routers/queue_router.py
+++ b/backend/api/routers/queue_router.py
@@ -196,7 +196,7 @@ async def queue_remove_track(body: QueueRemoveTrackRequest, req: Request) -> Res
     Remove a track at the specified index from the play queue.
 
     Args:
-        body (QueueRemoveTrackRequest): Request body containing the index of the track to remove.
+        body (QueueRemoveTrackRequest): Request body containing the id and index of the track to remove.
         req (Request): FastAPI request object to access app state.
 
     Returns:
@@ -206,6 +206,7 @@ async def queue_remove_track(body: QueueRemoveTrackRequest, req: Request) -> Res
         HTTPException: Returns 400 if the index is invalid (out of range).
         HTTPException: Returns 500 if any unexpected error occurs during processing.
     """
+    id = body.id
     index = int(body.index) #guaranteed by schema and by js default param
 
     queue_manager = req.app.state.queue_manager
@@ -216,7 +217,8 @@ async def queue_remove_track(body: QueueRemoveTrackRequest, req: Request) -> Res
         raise HTTPException(status_code=400, detail="Invalid index")
 
     try:
-        await play_queue.remove_at(index)
+        #include id just to make sure the right item is removed, this executes nothing if id doesn't match at index.
+        await play_queue.remove_at(id, index)
         return Response(status_code=204)
     except Exception as e:
         traceback.print_exc()

--- a/backend/api/schemas/queue_schemas.py
+++ b/backend/api/schemas/queue_schemas.py
@@ -15,6 +15,7 @@ class QueuePushTrackRequest(BaseModel):
 #QueuePopTrackRequest no need to implement
 
 class QueueRemoveTrackRequest(BaseModel):
+    id: str
     index: int = 0
 
 #QueueContentRequest no need to implement

--- a/backend/core/queue/base/doubly_linked_list.py
+++ b/backend/core/queue/base/doubly_linked_list.py
@@ -83,6 +83,37 @@ class DoublyLinkedList(Generic[T]):
         for _ in range(index):
             current = current.next
         return current.value if current else None
+    
+    def remove_at(self, index: int) -> Optional[T]:
+        if index < 0 or index >= self.size:
+            return None
+        if index == 0: #remove head
+            return self.pop()
+        
+        if index == self.size - 1: #remove tail
+            current = self.tail
+            self.tail = current.prev
+            if self.tail:
+                self.tail.next = None
+            else:
+                self.head = None
+            self.size -= 1
+            return current.value
+        
+        current = self.head #remove middle
+        for _ in range(index):
+            current = current.next
+        prev_node = current.prev
+        next_node = current.next
+
+        if prev_node:
+            prev_node.next = next_node
+        if next_node:
+            next_node.prev = prev_node
+
+        self.size -= 1
+        return current.value
+        
 
     def contains(self, item: T) -> bool:
         return any(x == item for x in self)

--- a/backend/core/queue/base/observable_dll.py
+++ b/backend/core/queue/base/observable_dll.py
@@ -48,11 +48,8 @@ class ObservableQueue(Generic[T], ABC):
         self._dll.insert_at(index, item)
 
     def _remove_at(self, index: int) -> Optional[T]:
-        # you would need to implement remove_at in DoublyLinkedList too
-        raise NotImplementedError("Implement remove_at in DoublyLinkedList")
-        # item = self._dll.remove_at(index)
-        # await self._emit_event("remove", {"index": index, "item": item, "size": self.size()})
-        # return item
+        item = self._dll.remove_at(index)
+        return item
 
     # ===== Public Read-only APIs =====
     def __iter__(self):

--- a/backend/core/queue/implementations/play_queue.py
+++ b/backend/core/queue/implementations/play_queue.py
@@ -50,11 +50,14 @@ class PlayQueue(ObservableQueue[str]):
 
             print(f"[DEBUG]: contents of play queue: {self.to_json()}")
 
-    async def remove_at(self, index: int):
+    async def remove_at(self, id: str, index: int):
         #remove track
         async with self._lock:
-            id = self._remove_at(index)
-            await self._emit_event(action=PQA.REMOVE, payload={"id": id, "content": self.to_json()})
+            check_id = self.peek_at(index)
+
+            if id == check_id:
+                id = self._remove_at(index)
+                await self._emit_event(action=PQA.REMOVE, payload={"id": id, "content": self.to_json()})
 
             print(f"[DEBUG]: contents of play queue: {self.to_json()}")
 

--- a/frontend/js/cache/QueueStore.js
+++ b/frontend/js/cache/QueueStore.js
@@ -6,49 +6,110 @@ export const QueueStore = (() => {
 
     return {
         // getters
+        /**
+         * Get the total number of items currently in the queue.
+         * @returns {number}
+         */
         length() {
             return store.length;
         },
+
+        /**
+         * Peek at the ID at the front of the queue without removing it.
+         * @returns {string|null} The track ID, or null if empty.
+         */
         peekId() {
             const ids = store.getIds();
             return ids[0] || null;
         },
+
+         /**
+         * Peek at the full track object at the front of the queue.
+         * @returns {object|null} The track object, or null if empty.
+         */
         peekTrack() {
             const id = this.peekId();
-            return id? TrackStore.get(id) : null;
+            return id ? TrackStore.get(id) : null;
         },
 
+        /**
+         * Get a copy of the queue's ID list.
+         * @returns {string[]} Array of IDs.
+         */
         getIds() {
             return store.getIds();
         },
+
+        /**
+         * Get the full track objects for each ID in the queue.
+         * @returns {object[]} Array of track objects.
+         */
         getTracks() {
             return store.getTracks(TrackStore);
         },
 
         // setters / sync
+        /**
+         * Replace the entire queue with a new list of IDs.
+         * @param {string[]} ids - New queue order.
+         */
         setAll(ids) {
             store.setAll(ids);
         },
+
+        /**
+         * Clear the entire queue.
+         */
         clear() {
             store.clear();
         },
 
         // operations
+        /**
+         * Push an ID to the end of the queue (tail).
+         * @param {string} id - Track ID to enqueue.
+         */
         push(id) {
             store.push(id);
         },
+
+        /**
+         * Insert an ID near the front of the queue (index 1), keeping the current front intact.
+         * Useful for “Play Next” functionality.
+         * @param {string} id - Track ID to insert.
+         */
         pushFront(id) {
             store.insert(id, 1);
         },
+
+        /**
+         * Pop and return the ID at the front of the queue (head).
+         * @returns {string|null} Removed ID or null if queue is empty.
+         */
         pop() {
             return store.pop();
         },
-        removeAt(index) {
+
+        /**
+         * Conditionally remove an item at a specific index, only if the ID matches.
+         * @param {string} id - Expected ID at that index.
+         * @param {number} index - Index to remove.
+         * @returns {string|null} Removed ID or null if failure.
+         */
+        removeAt(id, index) {
             const ids = store.getIds();
-            if (index >= 0 && index < ids.length) {
-                store.remove(ids[index]);
+            if (index >= 0 && index < ids.length && ids[index] === id) {
+                return store.removeAt(index);
             }
+            return null;
         },
+
+
+        /**
+         * Replace the first item in the queue with a new ID.
+         * This effectively “skips” the current item and replaces it.
+         * @param {string} id - ID to insert at the front.
+         */
         setFirst(id) {
             store.pop();
             store.insert(id, 0);

--- a/frontend/js/cache/utils/IdStore.js
+++ b/frontend/js/cache/utils/IdStore.js
@@ -43,6 +43,13 @@ export function createIdStore() {
         remove(id) {
             idList = idList.filter(x => x !== id);
         },
+        removeAt(index) {
+            if (index < 0 || index >= idList.length) {
+                return null;
+            }
+            const [removed] = idList.splice(index, 1);
+            return removed || null;
+        },
         
         //setters
         clear() {

--- a/frontend/js/dom/builders/list.js
+++ b/frontend/js/dom/builders/list.js
@@ -91,15 +91,18 @@ export const QUEUE_ACTIONS = Object.freeze({
  */
 export function buildTrackListItem(track, options = {}) {
     const {
-        index = null,
+        showIndex = false,
+        index = -1,
+        indexOffset = 1, //offset the shown text value
         actions = DEFAULT_ACTIONS,
     } = options;
 
     const li = document.createElement("li");
     li.classList.add("list-track-item");
 
-    //store track id
+    //store track id and index if available
     li.dataset.trackId = track.id;
+    li.dataset.index = index;
 
     //store action names in dataset (if present)
     for (const pos of ["right", "rightDeep", "left", "leftDeep"]) {
@@ -121,10 +124,10 @@ export function buildTrackListItem(track, options = {}) {
     ` : "";
 
     //build the index if needed
-    const positionArea = index != null ? `
+    const positionArea = showIndex ? `
         <div class="position">
             <a class="no-link" href="#">
-                <p class="position-value">${(index) + 1}</p>
+                <p class="position-value">${index + indexOffset}</p>
             </a>
         </div>
     ` : "";

--- a/frontend/js/events/mobile/swipe.js
+++ b/frontend/js/events/mobile/swipe.js
@@ -375,9 +375,7 @@ export function setupSwipeEventListeners() {
         if (actionName) {
 
             //execute swipe action handler: see frontend/js/features/playlist/controller.js
-            onSwipe(activeEl.dataset.trackId, actionName);
-
-            logDebug("actionName:", actionName);
+            onSwipe(activeEl.dataset, actionName);
         }
 
         //reset swipe state and visuals

--- a/frontend/js/features/playlist/lib/ui.js
+++ b/frontend/js/features/playlist/lib/ui.js
@@ -53,6 +53,7 @@ export function renderPlaylist(listEl, tracks, showIndex = true, actions = DEFAU
         //build rows
         tracks.forEach((track, index) => {
             const options = {
+                showIndex: showIndex,
                 index: index,
                 actions: actions,
             };
@@ -62,6 +63,7 @@ export function renderPlaylist(listEl, tracks, showIndex = true, actions = DEFAU
     } else {
         tracks.forEach((track) => {
             const options = {
+                showIndex: showIndex,
                 actions: actions,
             };
             const item = buildTrackListItem(track, options);

--- a/frontend/js/features/queue/lib/api.js
+++ b/frontend/js/features/queue/lib/api.js
@@ -62,8 +62,8 @@ export async function queuePopTrack() {
 }
 
 
-export async function queueRemoveTrack(index) {
-    const response = await postRequest(`/queue/remove-at`, { index });
+export async function queueRemoveTrack(id, index) {
+    const response = await postRequest(`/queue/remove-at`, { id, index });
     console.log("queueRemoveTrack status:", response.status);
 }
 

--- a/frontend/js/features/queue/lib/ui.js
+++ b/frontend/js/features/queue/lib/ui.js
@@ -31,10 +31,13 @@ export function renderQueueList(queueListEl, tracks) {
         return;
     }
 
-    //build rows
+    //build rows, set their data with their true index values (based on QueueStore), then offset by 0
     tracks.forEach((track, index) => {
+        const trueQueueIndex = index + 1;
         const options = {
-            index: index,
+            showIndex: true,
+            index: trueQueueIndex,
+            indexOffset: 0,
             actions: QUEUE_ACTIONS
         };
         const item = buildTrackListItem(track, options);


### PR DESCRIPTION
…vailable in rendering a trackListItem, which now has offset of 1. The data-index value of each element should reflect the element's index in the QueueStore or PlaylistStore, while the offset can edit the shown value via text. so for the queue, the first item (currently playing) is index 0, and all the other stuff is in the queue and technically index 1 through n, while offset is 0 to account for their correct visual indices.

* removeAt has a few differences, at the lowest possible level (backend is dll, frontend is createIdStore) it just remove(index), but one level of abstraction up (backend this is ObservableQueue, and frontend is QueueStore) assures that the id matches the value at that index, in order to prevent possible race conditions in the future