### PR TITLE
Auto update ytdlp

### DIFF
--- a/backend/api/routers/search_router.py
+++ b/backend/api/routers/search_router.py
@@ -57,7 +57,7 @@ async def deep_search(req: Request, q: Optional[str] = Query(None)):
     yt: YouTubeClient = req.app.state.yt
     db: AudioDatabase = req.app.state.db #put into db?
 
-    results = await yt.robust_search(q)
+    results = await yt.search(q)
 
     for track in results:
         print("ATTEMPTING LOG TRACK:", track)

--- a/backend/core/youtube/client.py
+++ b/backend/core/youtube/client.py
@@ -245,36 +245,6 @@ class YouTubeClient:
         return results
 
 
-    async def robust_search(
-        self,
-        q: str,
-        limit: int = 3,
-        timeout: int = 60,
-        max_attempts: int = 3,
-        base_delay: int = 1,
-        factor: int = 2,
-        max_delay: int = 20
-    ) -> List[Track]:
-        """
-        Robust search wrapper around `search` with retries and exponential backoff.
-        Returns an empty list if all attempts fail.
-        """
-        func_kwargs = dict(q=q, limit=limit, timeout=timeout)
-        try:
-            # Wrap the raw search in the retry helper
-            return await self._retry_async(
-                self.search,
-                max_attempts=max_attempts,
-                base_delay=base_delay,
-                factor=factor,
-                max_delay=max_delay,
-                **func_kwargs
-            )
-        except Exception as e:
-            print(f"[ERROR] Robust search for '{q}' failed after retries: {e}")
-            return []
-
-
     async def download_by_id(
         self,
         id: str, 
@@ -384,7 +354,7 @@ class YouTubeClient:
         custom_metadata: Optional[dict] = None
     ) -> bool:
         
-        result = await self.robust_search(q=q, limit=1, timeout=timeout) #doesnt emit when searching 1 item
+        result = await self.search(q=q, limit=1, timeout=timeout) #doesnt emit when searching 1 item
 
         if not result:
             print(f"[WARN]: No results found for query: {q}")

--- a/tests/core/youtube/test_client.py
+++ b/tests/core/youtube/test_client.py
@@ -52,7 +52,7 @@ async def test_download_by_query(tmp_path: Path):
 
     track = await client.download_by_query(q=query)
 
-    search_results = await client.robust_search(q=query, limit=1)
+    search_results = await client.search(q=query, limit=1)
     assert search_results, "Search returned no results"
     expected_track = search_results[0]
 
@@ -65,7 +65,7 @@ async def test_download_by_query(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_robust_search(tmp_path: Path):
+async def test_search(tmp_path: Path):
     client = YouTubeClient(
         name="test",
         base_dir=tmp_path
@@ -73,7 +73,7 @@ async def test_robust_search(tmp_path: Path):
 
     query = "rick astley never gonna give you up"
 
-    results = await client.robust_search(q=query)
+    results = await client.search(q=query)
 
     assert results, "Search returned no results"
     assert len(results) == 3, f"Expected 3 results, got {len(results)}"


### PR DESCRIPTION
added changes to automatically attempt fixing yt-dlp if possible on failure. we'll have to wait and see if this works, because writing a test case would be a lot of work.

also removed robust_search, which used exponential backoff to retry searches. instead, just use the fallback option of a one time retry on failure after attempting to fix yt-dlp.